### PR TITLE
feat: add background and zoom options to 3D SVG conversion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "svg.tscircuit.com",
       "dependencies": {
         "@tscircuit/simple-3d-svg": "^0.0.22",
-        "circuit-json-to-simple-3d": "^0.0.5",
+        "circuit-json-to-simple-3d": "^0.0.8",
         "circuit-to-svg": "^0.0.158",
         "jscad-fiber": "^0.0.85",
         "react-reconciler": "^0.31.0",
@@ -282,7 +282,7 @@
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.22", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg=="],
 
-    "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.5", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-hmFDzkLV9X9R6+OMheHmmLOk4aVG6HqWWU034O+xNRlZXxKHAdD9RTQdowU6QnQpZVMXO8NNVWdFcsjLf5Rvkw=="],
+    "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.8", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-ZQJB625ntNUS0hC3dFZtyFS+t2oL4PVysHlNQdGqpJFefwRXLCOjiXj0qS4ihE1SSl8indv+FCoCzJS/Kp6JHw=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.158", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "circuit-json": "*", "schematic-symbols": "*" } }, "sha512-TdKxfJ3x+5/cT8wbyXC++jvsEWacKS0KWRcKNZ8qvz73nPcs8y5+iUUH1c0k6YkkY1aZwrjiTqYNYVtTSuySyg=="],
 

--- a/endpoint.ts
+++ b/endpoint.ts
@@ -136,7 +136,13 @@ export default async (req: Request) => {
     } else if (svgType === "schematic") {
       svgContent = convertCircuitJsonToSchematicSvg(circuitJson)
     } else {
-      svgContent = await convertCircuitJsonToSimple3dSvg(circuitJson)
+      svgContent = await convertCircuitJsonToSimple3dSvg(circuitJson, {
+        background: {
+          color: "#fff",
+          opacity: 0.0,
+        },
+        defaultZoomMultiplier: 1.2,
+      })
     }
   } catch (err) {
     return errorResponse(err as Error)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@tscircuit/simple-3d-svg": "^0.0.22",
-    "circuit-json-to-simple-3d": "^0.0.5",
+    "circuit-json-to-simple-3d": "^0.0.8",
     "circuit-to-svg": "^0.0.158",
     "jscad-fiber": "^0.0.85",
     "react-reconciler": "^0.31.0",


### PR DESCRIPTION
Add background color/opacity and default zoom multiplier parameters to the 3D SVG conversion function to provide more control over the output visualization