### PR TITLE
Add PR cleanup to update-package workflow

### DIFF
--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -35,6 +35,9 @@ jobs:
               bun update --latest "$package"
             fi
           done
+      - name: Close existing PRs
+        run: |
+          gh pr list --repo ${{ github.repository }} --state open --author "tscircuitbot" --json number,title --jq '.[] | select(.title | startswith("chore:")) | .number' | xargs -I{} gh pr close {} --comment "Closing in favor of a new update PR"
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v5

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -2,6 +2,16 @@ import getPort from "get-port"
 import endpoint from "../../endpoint"
 import { afterEach } from "bun:test"
 
+const activeServers = new Set<ReturnType<typeof Bun.serve>>()
+
+afterEach(() => {
+  for (const server of activeServers) {
+    server.stop()
+  }
+
+  activeServers.clear()
+})
+
 export const getTestServer = async () => {
   const port = await getPort()
 
@@ -13,9 +23,7 @@ export const getTestServer = async () => {
     idleTimeout: 20,
   })
 
-  afterEach(() => {
-    server.stop()
-  })
+  activeServers.add(server)
 
   return {
     serverUrl,


### PR DESCRIPTION
## Summary
- regenerate the update-package workflow from @tscircuit/plop so it stays in sync with the shared template
- close existing bot-generated pull requests before creating a new update PR

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68debb98dab0832e927ea1391eb58a53