### PR TITLE
test(ci): defer server cleanup via global afterEach

### DIFF
--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -1,6 +1,5 @@
 import getPort from "get-port"
 import endpoint from "../../endpoint"
-import { afterEach } from "bun:test"
 
 export const getTestServer = async () => {
   const port = await getPort()
@@ -12,9 +11,9 @@ export const getTestServer = async () => {
     fetch: endpoint,
     idleTimeout: 20,
   })
-
-  afterEach(() => {
-    server.stop()
+  ;(globalThis as any).servers?.push({
+    url: serverUrl,
+    close: () => server.stop(),
   })
 
   return {

--- a/tests/fixtures/preload-server-cleanup.ts
+++ b/tests/fixtures/preload-server-cleanup.ts
@@ -1,0 +1,22 @@
+import { afterEach } from "bun:test"
+
+declare global {
+  // Keep a list of servers to close after each test
+  var servers: { url: string; close: () => void }[] | undefined
+}
+
+if (!globalThis.servers) {
+  globalThis.servers = []
+}
+
+afterEach(() => {
+  if (!globalThis.servers) return
+  for (const server of globalThis.servers) {
+    try {
+      server.close()
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  globalThis.servers = []
+})

--- a/tests/fixtures/preload.ts
+++ b/tests/fixtures/preload.ts
@@ -1,1 +1,2 @@
 import "bun-match-svg"
+import "./preload-server-cleanup"


### PR DESCRIPTION
 • Add tests/fixtures/preload-server-cleanup.ts with a single afterEach that closes all spawned Bun servers using a        
   for...of loop (not forEach).                                                                                            
 • Push newly created servers into globalThis.servers in get-test-server.ts.                                               
 • Import the cleanup preloader in tests/fixtures/preload.ts so it’s active for all tests.                                 