### PR TITLE
Fix generate_urls endpoint body handling

### DIFF
--- a/handlers/generate_urls.ts
+++ b/handlers/generate_urls.ts
@@ -16,10 +16,26 @@ export const generateUrlsHandler = async (
   }
 
   try {
-    const body = await req.json()
-    const { fs_map, entrypoint } = body
+    const body = ctx.requestBody
+    if (!body || typeof body !== "object") {
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: "Invalid or missing JSON body",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      )
+    }
 
-    if (!fs_map) {
+    const { fs_map, entrypoint } = body as {
+      fs_map?: Record<string, string>
+      entrypoint?: string
+    }
+
+    const fsMap = fs_map ?? ctx.fsMap
+    const resolvedEntrypoint = entrypoint ?? ctx.entrypoint
+
+    if (!fsMap) {
       return new Response(
         JSON.stringify({ ok: false, error: "No fsMap provided" }),
         { status: 400, headers: { "Content-Type": "application/json" } },
@@ -27,7 +43,10 @@ export const generateUrlsHandler = async (
     }
 
     return new Response(
-      getHtmlForGeneratedUrlPage({ fsMap: fs_map, entrypoint }, ctx.host),
+      getHtmlForGeneratedUrlPage(
+        { fsMap, entrypoint: resolvedEntrypoint },
+        ctx.host,
+      ),
       {
         headers: { "Content-Type": "text/html" },
       },

--- a/tests/generate-urls.test.ts
+++ b/tests/generate-urls.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "./fixtures/get-test-server"
+
+test("POST /generate_urls returns HTML without re-reading the body", async () => {
+  const { serverUrl } = await getTestServer()
+
+  const response = await fetch(`${serverUrl}/generate_urls`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fs_map: {
+        "index.tsx": `export default () => (
+  <board width="10mm" height="10mm">
+    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+  </board>
+)`,
+      },
+      entrypoint: "index.tsx",
+    }),
+  })
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get("content-type")).toContain("text/html")
+  const html = await response.text()
+  expect(html).toContain("svg.tscircuit.com - Generated URLs")
+})


### PR DESCRIPTION
## Summary
- reuse the request context body inside the generate_urls handler to avoid double reads
- add validation and fallbacks when building the generated URL response
- cover the regression with a Bun test that posts to /generate_urls

## Testing
- bun test tests/generate-urls.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68ec206b3be8832ebec9b0f94e4e9450