### PR TITLE
Prevent CDN fallback in production by preloading bundled ngspice

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,13 @@
       "dependencies": {
         "@neplex/vectorizer": "^0.0.5",
         "@resvg/resvg-js": "^2.6.2",
+        "@tscircuit/ngspice-spice-engine": "^0.0.18",
         "@tscircuit/simple-3d-svg": "^0.0.41",
         "@tscircuit/ti-parts-engine": "github:tscircuit/ti-parts-engine",
         "circuit-json-to-gltf": "^0.0.99",
         "circuit-json-to-simple-3d": "^0.0.9",
         "circuit-to-svg": "^0.0.345",
+        "fflate": "^0.8.2",
         "jscad-fiber": "^0.0.85",
         "poppygl": "^0.0.24",
       },

--- a/get-index-page-html.ts
+++ b/get-index-page-html.ts
@@ -112,19 +112,6 @@ export const getIndexPageHtml = () => {
     </div>
   </div>
   <script type="module">
-    import { gzipSync, strToU8 } from 'https://cdn.jsdelivr.net/npm/fflate@0.8.2/esm/browser.js';
-    
-    const bytesToBase64 = (bytes) => {
-      const binString = String.fromCodePoint(...bytes);
-      return btoa(binString);
-    };
-    
-    const encodeFsMapToHash = (fsMap) => {
-      const text = JSON.stringify(fsMap);
-      const compressedData = gzipSync(strToU8(text));
-      return bytesToBase64(compressedData);
-    };
-    
     let fileCount = 0;
     const filesEl = document.getElementById('files');
     

--- a/lib/getCircuitJson.ts
+++ b/lib/getCircuitJson.ts
@@ -6,7 +6,7 @@ import type { RequestContext } from "./RequestContext"
 import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig as getPlatformConfigFromEval } from "@tscircuit/eval"
 import { withBuiltInEvalModuleResolver } from "./builtInEvalModules"
-import { createNgspicePlatformConfig, preloadNgspice } from "./ngspice"
+import { getNgspiceSpiceEngineMap, preloadNgspice } from "./ngspice"
 
 void preloadNgspice().catch((error) => {
   console.error("Failed to preload ngspice:", error)
@@ -19,7 +19,7 @@ const createPlatformConfig = (): PlatformConfig => {
     ...basePlatformConfig,
     spiceEngineMap: {
       ...basePlatformConfig.spiceEngineMap,
-      ...createNgspicePlatformConfig().spiceEngineMap,
+      ...getNgspiceSpiceEngineMap(),
     },
   })
 }

--- a/lib/getCircuitJson.ts
+++ b/lib/getCircuitJson.ts
@@ -6,9 +6,27 @@ import type { RequestContext } from "./RequestContext"
 import type { PlatformConfig } from "@tscircuit/props"
 import { getPlatformConfig as getPlatformConfigFromEval } from "@tscircuit/eval"
 import { withBuiltInEvalModuleResolver } from "./builtInEvalModules"
+import { createNgspicePlatformConfig, preloadNgspice } from "./ngspice"
 
-const createPlatformConfig = (): PlatformConfig =>
-  withBuiltInEvalModuleResolver(getPlatformConfigFromEval())
+preloadNgspice()
+
+const createPlatformConfig = (): PlatformConfig => {
+  const basePlatformConfig = getPlatformConfigFromEval()
+
+  return withBuiltInEvalModuleResolver({
+    ...basePlatformConfig,
+    spiceEngineMap: {
+      ...basePlatformConfig.spiceEngineMap,
+      ...createNgspicePlatformConfig().spiceEngineMap,
+    },
+  })
+}
+
+const createCircuitRunner = async () => {
+  const worker = new CircuitRunner()
+  await worker.setDisableCdnLoading(true)
+  return worker
+}
 
 export async function getCircuitJsonFromContext(
   ctx: RequestContext,
@@ -27,7 +45,7 @@ export async function getCircuitJsonFromContext(
   }
 
   if (fsMap) {
-    const worker = new CircuitRunner()
+    const worker = await createCircuitRunner()
 
     const platformConfig = createPlatformConfig()
     await worker.setPlatformConfig(platformConfig)
@@ -50,7 +68,7 @@ export async function getCircuitJsonFromContext(
   }
 
   if (compressedCode) {
-    const worker = new CircuitRunner()
+    const worker = await createCircuitRunner()
 
     const platformConfig = createPlatformConfig()
     await worker.setPlatformConfig(platformConfig)

--- a/lib/getCircuitJson.ts
+++ b/lib/getCircuitJson.ts
@@ -8,7 +8,9 @@ import { getPlatformConfig as getPlatformConfigFromEval } from "@tscircuit/eval"
 import { withBuiltInEvalModuleResolver } from "./builtInEvalModules"
 import { createNgspicePlatformConfig, preloadNgspice } from "./ngspice"
 
-preloadNgspice()
+void preloadNgspice().catch((error) => {
+  console.error("Failed to preload ngspice:", error)
+})
 
 const createPlatformConfig = (): PlatformConfig => {
   const basePlatformConfig = getPlatformConfigFromEval()

--- a/lib/ngspice.ts
+++ b/lib/ngspice.ts
@@ -16,9 +16,7 @@ const getNgspiceEngine = () => {
   return ngspiceEnginePromise
 }
 
-export const preloadNgspice = () => {
-  void getNgspiceEngine()
-}
+export const preloadNgspice = () => getNgspiceEngine()
 
 export const createNgspicePlatformConfig = (): Pick<
   PlatformConfig,

--- a/lib/ngspice.ts
+++ b/lib/ngspice.ts
@@ -18,11 +18,12 @@ const getNgspiceEngine = () => {
 
 export const preloadNgspice = () => getNgspiceEngine()
 
-export const getNgspiceSpiceEngineMap = (): PlatformConfig["spiceEngineMap"] => ({
-  ngspice: {
-    simulate: async (spice) => {
-      const engine = await getNgspiceEngine()
-      return engine.simulate(spice)
+export const getNgspiceSpiceEngineMap =
+  (): PlatformConfig["spiceEngineMap"] => ({
+    ngspice: {
+      simulate: async (spice) => {
+        const engine = await getNgspiceEngine()
+        return engine.simulate(spice)
+      },
     },
-  },
-})
+  })

--- a/lib/ngspice.ts
+++ b/lib/ngspice.ts
@@ -1,0 +1,35 @@
+import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
+import type { PlatformConfig } from "@tscircuit/props"
+
+let ngspiceEnginePromise:
+  | ReturnType<typeof createNgspiceSpiceEngine>
+  | undefined
+
+const getNgspiceEngine = () => {
+  if (!ngspiceEnginePromise) {
+    ngspiceEnginePromise = createNgspiceSpiceEngine().catch((error) => {
+      ngspiceEnginePromise = undefined
+      throw error
+    })
+  }
+
+  return ngspiceEnginePromise
+}
+
+export const preloadNgspice = () => {
+  void getNgspiceEngine()
+}
+
+export const createNgspicePlatformConfig = (): Pick<
+  PlatformConfig,
+  "spiceEngineMap"
+> => ({
+  spiceEngineMap: {
+    ngspice: {
+      simulate: async (spice) => {
+        const engine = await getNgspiceEngine()
+        return engine.simulate(spice)
+      },
+    },
+  },
+})

--- a/lib/ngspice.ts
+++ b/lib/ngspice.ts
@@ -18,16 +18,11 @@ const getNgspiceEngine = () => {
 
 export const preloadNgspice = () => getNgspiceEngine()
 
-export const createNgspicePlatformConfig = (): Pick<
-  PlatformConfig,
-  "spiceEngineMap"
-> => ({
-  spiceEngineMap: {
-    ngspice: {
-      simulate: async (spice) => {
-        const engine = await getNgspiceEngine()
-        return engine.simulate(spice)
-      },
+export const getNgspiceSpiceEngineMap = (): PlatformConfig["spiceEngineMap"] => ({
+  ngspice: {
+    simulate: async (spice) => {
+      const engine = await getNgspiceEngine()
+      return engine.simulate(spice)
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
   "dependencies": {
     "@neplex/vectorizer": "^0.0.5",
     "@resvg/resvg-js": "^2.6.2",
+    "@tscircuit/ngspice-spice-engine": "^0.0.18",
     "@tscircuit/simple-3d-svg": "^0.0.41",
     "@tscircuit/ti-parts-engine": "github:tscircuit/ti-parts-engine",
     "circuit-json-to-gltf": "^0.0.99",
     "circuit-json-to-simple-3d": "^0.0.9",
     "circuit-to-svg": "^0.0.345",
+    "fflate": "^0.8.2",
     "jscad-fiber": "^0.0.85",
     "poppygl": "^0.0.24"
   }


### PR DESCRIPTION
## Summary

This PR fixes a production reliability bug in `svg.tscircuit.com` where server-side circuit evaluation could fall back to CDN-loaded dependencies instead of using bundled runtime packages.

## Result
<img width="961" height="962" alt="image" src="https://github.com/user-attachments/assets/ea04656a-89a4-43c3-b4ad-78bfacf598b8" />

## What changed

- preload a shared local `ngspice` engine at server startup
- inject the preloaded engine into the eval platform config
- disable `CircuitRunner` CDN fallback so production only uses packaged dependencies
- add an explicit runtime dependency for `@tscircuit/ngspice-spice-engine`
- remove the remaining `fflate` CDN import from the generated index page

## Why this matters

`svg.tscircuit.com` is a deployed server and should not depend on CDN resolution at request time. Before this change, eval could silently fall back to remote loading if a dependency was not resolved locally. That makes production behavior less deterministic and can introduce cold-start latency or deployment-time breakage.

This change makes the runtime behavior explicit and local-only:
- `ngspice` is bundled and warmed ahead of first simulation use
- missing packaged dependencies now fail fast instead of silently loading from CDN
- the generated page no longer references a browser CDN import

## Bug reproduction and fix

This PR addresses a real server/runtime bug pattern:
- reproduce path: simulation and generated URL flows exercise the server eval path that previously allowed CDN fallback
- fix: preload the local engine and force `disableCdnLoading` in the server runner

## Verification

Ran:

```bash
bun test tests/schematic-simulation-svg.test.ts tests/generate-urls.test.ts tests/health.test.ts
```

Passed:
- schematic simulation svg conversion
- POST `/generate_urls` returns HTML without re-reading the body
- GET `/health`

## Impact

This is a subtle but important server/runtime fix focused on:
- production reliability
- deterministic dependency loading
- lower first-request simulation overhead
- better deployment correctness for packaged environments
