### PR TITLE
Fix ngspice simulation failing in production with blob: ESM loader error

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@neplex/vectorizer": "^0.0.5",
         "@resvg/resvg-js": "^2.6.2",
+        "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.4.tgz",
         "@tscircuit/ngspice-spice-engine": "^0.0.18",
         "@tscircuit/simple-3d-svg": "^0.0.41",
         "@tscircuit/ti-parts-engine": "github:tscircuit/ti-parts-engine",
@@ -20,7 +21,6 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@tscircuit/create-snippet-url": "^0.0.13",
-        "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.4.tgz",
         "@types/bun": "latest",
         "@types/react": "19.0.8",
         "bun-match-svg": "^0.0.14",

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,10 @@ const nextConfig = {
   transpilePackages: ["@tscircuit/ti-parts-engine"],
   experimental: {
     outputFileTracingIncludes: {
-      "/api/*": ["node_modules/manifold-3d/**/*"],
+      "/api/*": [
+        "node_modules/manifold-3d/**/*",
+        "node_modules/@tscircuit/eecircuit-engine/**/*",
+      ],
     },
   },
   rewrites() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/create-snippet-url": "^0.0.13",
-    "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.4.tgz",
     "@types/bun": "latest",
     "@types/react": "19.0.8",
     "bun-match-svg": "^0.0.14",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@neplex/vectorizer": "^0.0.5",
     "@resvg/resvg-js": "^2.6.2",
+    "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.4.tgz",
     "@tscircuit/ngspice-spice-engine": "^0.0.18",
     "@tscircuit/simple-3d-svg": "^0.0.41",
     "@tscircuit/ti-parts-engine": "github:tscircuit/ti-parts-engine",

--- a/scripts/apply-dependency-patches.mjs
+++ b/scripts/apply-dependency-patches.mjs
@@ -47,4 +47,60 @@ function patchOcctImportJs() {
   console.log("[postinstall] patched occt-import-js to preload STEP wasm")
 }
 
+const ngspiceEngineIndexPath = path.join(
+  projectRoot,
+  "node_modules",
+  "@tscircuit",
+  "ngspice-spice-engine",
+  "dist",
+  "index.js",
+)
+
+// @tscircuit/ngspice-spice-engine resolves @tscircuit/eecircuit-engine through a
+// dynamic import with a *variable* specifier (`import(moduleName)`). Neither
+// webpack nor @vercel/nft can statically analyze a variable specifier, so the
+// engine is never bundled into the Next.js serverless function. At runtime the
+// installed import fails and the engine falls back to loading the package from
+// the CDN via a `blob:` URL, which Node's ESM loader rejects
+// ("Only URLs with a scheme in: file, data, and node are supported ... Received
+// protocol 'blob:'"). Rewriting the specifier to a literal string makes the
+// import analyzable so the engine is traced/bundled and the installed path
+// succeeds, avoiding the CDN fallback entirely.
+const ngspiceOriginalSnippet =
+  "const moduleName = EECIRCUIT_ENGINE_PACKAGE;\n    const mod = await import(moduleName);"
+
+const ngspicePatchedSnippet =
+  'const mod = await import("@tscircuit/eecircuit-engine");'
+
+function patchNgspiceSpiceEngine() {
+  if (!existsSync(ngspiceEngineIndexPath)) {
+    console.warn(
+      `[postinstall] Skipping ngspice-spice-engine patch, file not found: ${ngspiceEngineIndexPath}`,
+    )
+    return
+  }
+
+  const source = readFileSync(ngspiceEngineIndexPath, "utf8")
+
+  if (source.includes(ngspicePatchedSnippet)) {
+    console.log("[postinstall] ngspice-spice-engine already patched")
+    return
+  }
+
+  if (!source.includes(ngspiceOriginalSnippet)) {
+    throw new Error(
+      "[postinstall] ngspice-spice-engine patch target not found; upstream file changed",
+    )
+  }
+
+  writeFileSync(
+    ngspiceEngineIndexPath,
+    source.replace(ngspiceOriginalSnippet, ngspicePatchedSnippet),
+  )
+  console.log(
+    "[postinstall] patched ngspice-spice-engine to use a literal eecircuit-engine import",
+  )
+}
+
 patchOcctImportJs()
+patchNgspiceSpiceEngine()

--- a/tests/eecircuit-engine-trace.test.ts
+++ b/tests/eecircuit-engine-trace.test.ts
@@ -1,0 +1,34 @@
+import { existsSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { expect, test } from "bun:test"
+
+const tracePath = path.join(
+  process.cwd(),
+  ".next/server/pages/api/[...anyroute].js.nft.json",
+)
+
+const traceTest = existsSync(tracePath) ? test : test.skip
+
+const normalizeTracePath = (filePath: string) => filePath.replaceAll("\\", "/")
+
+// The ngspice spice engine dynamically imports @tscircuit/eecircuit-engine. If
+// the engine is not traced into the serverless function, the runtime import
+// fails and the engine falls back to loading it from a CDN via a `blob:` URL,
+// which Node's ESM loader rejects. Ensure the engine (which embeds its wasm in
+// the .mjs bundle) is included in the Next API trace.
+traceTest(
+  "Next API trace includes @tscircuit/eecircuit-engine for ngspice simulation",
+  async () => {
+    const trace = JSON.parse(await readFile(tracePath, "utf8")) as {
+      files: string[]
+    }
+
+    const tracedFiles = trace.files.map(normalizeTracePath)
+    const includesEngine = tracedFiles.some((file) =>
+      file.includes("node_modules/@tscircuit/eecircuit-engine/"),
+    )
+
+    expect(includesEngine).toBe(true)
+  },
+)


### PR DESCRIPTION
## Problem

Schematic simulation (`svg_type=schsim`) fails in production with:

> Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'blob:'

`@tscircuit/ngspice-spice-engine` resolves `@tscircuit/eecircuit-engine` (the actual ngspice/WASM engine) through a dynamic import with a **variable** specifier (`import(moduleName)`). Neither webpack nor `@vercel/nft` can statically analyze a variable specifier, so the engine is never traced into the Next.js serverless function. At runtime the installed import fails and the engine falls back to loading the package from the CDN via a `blob:` URL, which Node's ESM loader rejects.

## Fix

- **Patch the engine** (via the existing `scripts/apply-dependency-patches.mjs` postinstall) to use a literal `import("@tscircuit/eecircuit-engine")`, so the import is analyzable and the engine is traced/bundled — the installed path then succeeds and the CDN/`blob:` fallback is never reached.
- **Move `@tscircuit/eecircuit-engine` to `dependencies`** — it's required at runtime for ngspice simulation, not just tests.
- **Force-include the engine** in the API function via `outputFileTracingIncludes`, mirroring the existing `manifold-3d` handling. The engine embeds its wasm as a `data:` URL in the single `.mjs` bundle, so including that file is sufficient.
- **Add a trace test** asserting the engine is present in the Next API `.nft.json` trace (mirrors `manifold-trace.test.ts`).

## Verification

- `next build` → the `.next/server/pages/api/[...anyroute].js.nft.json` trace now includes `@tscircuit/eecircuit-engine/dist/eecircuit-engine.mjs`.
- `next start` → POSTing the board to `/?svg_type=schsim` (via `fsMap`, the CircuitRunner + ngspice path) returns a 200 schsim SVG with the simulation graph rendered, instead of the `blob:` error. No `blob:`/ESM-loader errors in the server log.

## Note

The underlying cause is the variable dynamic import in `@tscircuit/ngspice-spice-engine`; fixing that upstream to use a literal specifier would remove the need for the local patch here.