### PR TITLE
fix: load ngspice engine without blob: import (fixes schematic simulation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/create-snippet-url": "^0.0.13",
-    "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.4.tgz",
     "@types/bun": "latest",
     "@types/react": "19.0.8",
     "bun-match-svg": "^0.0.14",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@neplex/vectorizer": "^0.0.5",
     "@resvg/resvg-js": "^2.6.2",
+    "@tscircuit/eecircuit-engine": "https://jscdn.tscircuit.com/@tscircuit/eecircuit-engine/1.7.4.tgz",
     "@tscircuit/ngspice-spice-engine": "^0.0.18",
     "@tscircuit/simple-3d-svg": "^0.0.41",
     "@tscircuit/ti-parts-engine": "github:tscircuit/ti-parts-engine",

--- a/scripts/apply-dependency-patches.mjs
+++ b/scripts/apply-dependency-patches.mjs
@@ -19,6 +19,66 @@ const occtOriginalSnippet =
 const occtPatchedSnippet =
   'scriptDirectory=__dirname+"/";if(!Module["wasmBinary"]){Module["wasmBinary"]=fs.readFileSync(nodePath.join(__dirname,"occt-import-js.wasm"))}readBinary=filename=>{filename=isFileURI(filename)?new URL(filename):nodePath.normalize(filename);var ret=fs.readFileSync(filename);return ret};readAsync=(filename,binary=true)=>{filename=isFileURI(filename)?new URL(filename):nodePath.normalize(filename);return new Promise((resolve,reject)=>{fs.readFile(filename,binary?undefined:"utf8",(err,data)=>{if(err)reject(err);else resolve(binary?data.buffer:data)})})};'
 
+const ngspiceSpiceEnginePath = path.join(
+  projectRoot,
+  "node_modules",
+  "@tscircuit",
+  "ngspice-spice-engine",
+  "dist",
+  "index.js",
+)
+
+// @tscircuit/ngspice-spice-engine@0.0.18 loads its WASM engine via an
+// unconditional `URL.createObjectURL` + `import("blob:...")`, which the Node ESM
+// loader rejects ("Only URLs with a scheme in: file, data, and node are
+// supported... Received protocol 'blob:'"). This breaks schematic simulation on
+// the server. Import the locally bundled @tscircuit/eecircuit-engine instead,
+// which also avoids a runtime CDN fetch.
+const ngspiceOriginalSnippet = `    modulePromise = fetch(EECIRCUIT_ENGINE_URL).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(
+          \`Failed to load @tscircuit/eecircuit-engine from \${EECIRCUIT_ENGINE_URL}: \${response.status} \${response.statusText}\`
+        );
+      }
+      const source = await response.text();
+      const moduleUrl = URL.createObjectURL(
+        new Blob([source], { type: "text/javascript" })
+      );
+      return import(moduleUrl);
+    });`
+
+const ngspicePatchedSnippet = `    modulePromise = import("@tscircuit/eecircuit-engine");`
+
+function patchNgspiceSpiceEngine() {
+  if (!existsSync(ngspiceSpiceEnginePath)) {
+    console.warn(
+      `[postinstall] Skipping ngspice-spice-engine patch, file not found: ${ngspiceSpiceEnginePath}`,
+    )
+    return
+  }
+
+  const source = readFileSync(ngspiceSpiceEnginePath, "utf8")
+
+  if (source.includes(ngspicePatchedSnippet)) {
+    console.log("[postinstall] ngspice-spice-engine already patched")
+    return
+  }
+
+  if (!source.includes(ngspiceOriginalSnippet)) {
+    throw new Error(
+      "[postinstall] ngspice-spice-engine patch target not found; upstream file changed",
+    )
+  }
+
+  writeFileSync(
+    ngspiceSpiceEnginePath,
+    source.replace(ngspiceOriginalSnippet, ngspicePatchedSnippet),
+  )
+  console.log(
+    "[postinstall] patched ngspice-spice-engine to import bundled eecircuit-engine",
+  )
+}
+
 function patchOcctImportJs() {
   if (!existsSync(occtImportJsPath)) {
     console.warn(
@@ -48,3 +108,4 @@ function patchOcctImportJs() {
 }
 
 patchOcctImportJs()
+patchNgspiceSpiceEngine()

--- a/tests/ngspice-node-loader.test.ts
+++ b/tests/ngspice-node-loader.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { execFileSync } from "node:child_process"
+import path from "node:path"
+
+const projectRoot = path.join(import.meta.dir, "..")
+
+// Regression guard for the "Received protocol 'blob:'" failure during schematic
+// simulation. @tscircuit/ngspice-spice-engine loaded its WASM engine via
+// `import("blob:...")`, which the Node ESM loader rejects (bun supports it, so a
+// normal bun test does NOT catch this). We patch the package in postinstall to
+// import the bundled @tscircuit/eecircuit-engine instead. This test runs the
+// engine in a real Node process to exercise the loader that fails in production.
+test(
+  "ngspice engine simulates under the Node ESM loader (no blob: import)",
+  () => {
+    const script = [
+      'import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"',
+      'const spice = "* test\\nV1 1 0 5\\nR1 1 0 1k\\n.op\\n.end\\n"',
+      "const engine = await createNgspiceSpiceEngine()",
+      "await engine.simulate(spice)",
+      'console.log("NGSPICE_NODE_OK")',
+    ].join("\n")
+
+    // Must run under Node (not the bun test runtime): bun accepts blob: imports,
+    // so only a real Node process reproduces the production failure.
+    const stdout = execFileSync("node", ["--input-type=module", "-e", script], {
+      cwd: projectRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    expect(stdout).toContain("NGSPICE_NODE_OK")
+  },
+  { timeout: 60000 },
+)


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is a proof / stopgap, not the real fix.** It patches a dependency's
> built output in `node_modules` so schematic simulation works on the server
> today. The actual defect lives in `@tscircuit/ngspice-spice-engine` 

## Problem

Schematic simulation fails on the server with:

> Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'blob:'

**Root cause:** `@tscircuit/ngspice-spice-engine@0.0.18` loads its WASM engine via an unconditional `URL.createObjectURL` + `import("blob:...")`:

```js
// node_modules/@tscircuit/ngspice-spice-engine/dist/index.js
const source = await response.text();
const moduleUrl = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
return import(moduleUrl); // ← Node ESM loader rejects blob:
```

Node's ESM loader only accepts `file:`, `data:`, and `node:` schemes, so this throws the moment ngspice loads. It is the missing piece of #1686: `preloadNgspice()` hits this same import and silently fails, so the error only surfaces at simulate time.

## What this PR does (the workaround)

- **Patches the package in postinstall** (`scripts/apply-dependency-patches.mjs`, mirroring the existing `occt-import-js` patch with idempotency + "upstream changed" guards) to import the bundled `@tscircuit/eecircuit-engine` directly instead of fetching + blob-importing. This removes the blob import **and** the runtime CDN fetch (matching #1686's goal).
- **Promotes `@tscircuit/eecircuit-engine` to a runtime `dependency`** (pinned to `1.7.4`, the same version the package's hardcoded CDN URL referenced) since a runtime dependency now imports it.
- **Adds a Node-level regression test** (`tests/ngspice-node-loader.test.ts`). The existing bun tests can't catch this — bun *accepts* `blob:` imports — so the test spawns a real **Node** process to run `simulate()`.

## The real fix

The proper fix belongs in **`@tscircuit/ngspice-spice-engine`** (`lib/import-eecircuit-engine.ts`). Today it loads the engine the same way in every environment:

```js
const source = await response.text();
const moduleUrl = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
return import(moduleUrl);
```

`blob:` URLs only resolve in browsers/bun; the Node ESM loader rejects them — so the package is broken for **any** Node consumer, not just this repo. It should be environment-aware. Either:

1. **Branch on environment** — keep the CDN fetch, but in non-browser environments use a `data:` URL (which the Node loader accepts) instead of a blob URL. This is the minimal change and matches the pattern `@tscircuit/eval` already uses:
   ```js
   const dataUrl = `data:text/javascript;base64,${Buffer.from(source, "utf8").toString("base64")}`;
   return import(dataUrl);
   ```
2. **(Preferred) Import the package directly** — declare `@tscircuit/eecircuit-engine` as a real dependency and `return import("@tscircuit/eecircuit-engine")`, optionally falling back to the CDN. This avoids the network round-trip entirely and is exactly what this PR forces via the patch.

Once a fixed `@tscircuit/ngspice-spice-engine` is published, the follow-up here is trivial: bump the dependency and remove `patchNgspiceSpiceEngine()` from `scripts/apply-dependency-patches.mjs`.

## Verification

- ✅ Patch applies and is idempotent (re-run → "already patched")
- ✅ New guard **fails without** the patch (exact production error) and **passes with** it
- ✅ Existing `schematic-simulation-svg` test still passes
- ✅ Formatted with biome
