### PR TITLE
Fix ngspice engine loading in Node runtime

### DIFF
--- a/lib/ngspice.ts
+++ b/lib/ngspice.ts
@@ -1,13 +1,61 @@
-import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
+import { Simulation } from "@tscircuit/eecircuit-engine"
+import {
+  eecircuitResultToSimulationGraphs,
+  rewritePspiceCompatibilitySyntax,
+  simulationGraphsToCircuitJson,
+} from "@tscircuit/ngspice-spice-engine"
 import type { PlatformConfig } from "@tscircuit/props"
 
-let ngspiceEnginePromise:
-  | ReturnType<typeof createNgspiceSpiceEngine>
-  | undefined
+type NgspiceEngine = NonNullable<PlatformConfig["spiceEngineMap"]>[string]
+
+let simulationPromise: Promise<Simulation> | undefined
+
+const getSimulation = async () => {
+  if (!simulationPromise) {
+    simulationPromise = (async () => {
+      const simulation = new Simulation({ ngBehavior: "psa" })
+      await simulation.start()
+      return simulation
+    })().catch((error) => {
+      simulationPromise = undefined
+      throw error
+    })
+  }
+
+  return simulationPromise
+}
+
+const createNgspiceEngine = async (): Promise<NgspiceEngine> => ({
+  simulate: async (spiceString) => {
+    const simulation = await getSimulation()
+    const simulationSpiceString = rewritePspiceCompatibilitySyntax(spiceString)
+
+    simulation.setNetList(simulationSpiceString)
+    const result = await simulation.runSim()
+
+    if (!result) {
+      return { simulationResultCircuitJson: [] }
+    }
+
+    const graphs = eecircuitResultToSimulationGraphs(
+      result,
+      simulationSpiceString,
+    )
+
+    return {
+      simulationResultCircuitJson: simulationGraphsToCircuitJson(
+        graphs,
+        simulationSpiceString,
+      ),
+    }
+  },
+})
+
+let ngspiceEnginePromise: Promise<NgspiceEngine> | undefined
 
 const getNgspiceEngine = () => {
   if (!ngspiceEnginePromise) {
-    ngspiceEnginePromise = createNgspiceSpiceEngine().catch((error) => {
+    ngspiceEnginePromise = createNgspiceEngine().catch((error) => {
       ngspiceEnginePromise = undefined
       throw error
     })


### PR DESCRIPTION
 Avoid createNgspiceSpiceEngine() because it loads eecircuit-engine through a
  fetched blob: module URL, which fails under Node/Next production runtimes.
  Instantiate @tscircuit/eecircuit-engine directly and reuse the ngspice package’s
  existing SPICE rewrite/result conversion helpers to preserve the same
  simulationResultCircuitJson output shape.