### PR TITLE
Support selecting named simulation SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This service converts TSCircuit code or pre-generated circuit JSON into various 
   - `png_width` / `png_height`
   - `png_density`
 - `show_infinite_grid` (optional): For 3D views only. Set to `true` to display an infinite grid in the 3D render. Default: `false`
+- `simulation_experiment_id` (optional): For `sim` and `schsim`, render the experiment with this Circuit JSON id.
+- `simulation_experiment_name` (optional): For `sim` and `schsim`, render the uniquely named experiment. If neither selector is provided, the first experiment is rendered.
 
 **Input Methods:**
 - `code` (GET/POST query parameter): Base64-encoded and compressed TSCircuit code
@@ -150,6 +152,20 @@ curl "https://svg.tscircuit.com/?svg_type=pcb&format=png&code=YOUR_ENCODED_CODE"
 ```bash
 curl "https://svg.tscircuit.com/?svg_type=schematic&code=YOUR_ENCODED_CODE"
 ```
+
+**Named Simulation Graph:**
+```bash
+curl "https://svg.tscircuit.com/?svg_type=sim&simulation_experiment_name=Root%20Fast&code=YOUR_ENCODED_CODE"
+```
+
+**Named Schematic Simulation:**
+```bash
+curl "https://svg.tscircuit.com/?svg_type=schsim&simulation_experiment_name=Input%20Group&code=YOUR_ENCODED_CODE"
+```
+
+Each simulation request returns one static SVG. Use a unique `name` on every
+`<analogsimulation />`, then create one URL per name when presenting multiple
+simulation results. Use `simulation_experiment_id` when names are duplicated.
 
 **Assembly View:**
 ```bash

--- a/get-html-for-generated-url-page.ts
+++ b/get-html-for-generated-url-page.ts
@@ -3,21 +3,98 @@ import {
   type GeneratedUrlInput,
   type GeneratedSvgUrls,
 } from "./lib/createGeneratedSvgUrls"
+import type { SimulationExperiment } from "circuit-json"
+
+type SimulationExperimentForGeneratedUrl = Pick<
+  SimulationExperiment,
+  "simulation_experiment_id" | "name"
+>
+
+const escapeHtml = (value: string) =>
+  value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#039;",
+      })[character]!,
+  )
 
 const renderUrlRow = (label: string, url: string) => `
         <tr>
-          <td>${label}</td>
-          <td><a href="${url}" target="_blank">${url}</a></td>
+          <td>${escapeHtml(label)}</td>
+          <td><a href="${escapeHtml(url)}" target="_blank">${escapeHtml(url)}</a></td>
         </tr>`
 
-const renderGeneratedUrlRows = (urls: GeneratedSvgUrls) =>
+const selectSimulationExperiment = (
+  url: string,
+  experiment: SimulationExperimentForGeneratedUrl,
+  useName: boolean,
+) => {
+  const selectedUrl = new URL(url)
+  if (useName) {
+    selectedUrl.searchParams.set("simulation_experiment_name", experiment.name)
+  } else {
+    selectedUrl.searchParams.set(
+      "simulation_experiment_id",
+      experiment.simulation_experiment_id,
+    )
+  }
+  return selectedUrl.toString()
+}
+
+const renderSimulationUrlRows = (
+  urls: GeneratedSvgUrls,
+  simulationExperiments: SimulationExperimentForGeneratedUrl[],
+) => {
+  if (simulationExperiments.length === 0) {
+    return [
+      renderUrlRow("Schematic Simulation SVG URL", urls.schSimSvgUrl),
+      renderUrlRow("Simulation Graph SVG URL", urls.simSvgUrl),
+    ]
+  }
+
+  const nameCounts = new Map<string, number>()
+  for (const experiment of simulationExperiments) {
+    const name = experiment.name.trim()
+    if (name) nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1)
+  }
+
+  return simulationExperiments.flatMap((experiment) => {
+    const name = experiment.name.trim()
+    const useName = Boolean(name) && nameCounts.get(name) === 1
+    const label = useName
+      ? name
+      : name
+        ? `${name} (${experiment.simulation_experiment_id})`
+        : experiment.simulation_experiment_id
+
+    return [
+      renderUrlRow(
+        `Schematic Simulation SVG URL — ${label}`,
+        selectSimulationExperiment(urls.schSimSvgUrl, experiment, useName),
+      ),
+      renderUrlRow(
+        `Simulation Graph SVG URL — ${label}`,
+        selectSimulationExperiment(urls.simSvgUrl, experiment, useName),
+      ),
+    ]
+  })
+}
+
+const renderGeneratedUrlRows = (
+  urls: GeneratedSvgUrls,
+  simulationExperiments: SimulationExperimentForGeneratedUrl[],
+) =>
   [
     renderUrlRow("Package URL", urls.packageUrl),
     renderUrlRow("PCB SVG URL", urls.pcbSvgUrl),
     renderUrlRow("PCB PNG URL", urls.pcbPngUrl),
     renderUrlRow("Schematic SVG URL", urls.schSvgUrl),
-    renderUrlRow("Schematic Simulation SVG URL", urls.schSimSvgUrl),
-    renderUrlRow("Simulation Graph SVG URL", urls.simSvgUrl),
+    ...renderSimulationUrlRows(urls, simulationExperiments),
     renderUrlRow("Schematic PNG URL", urls.schPngUrl),
     renderUrlRow("Assembly SVG URL", urls.assemblySvgUrl),
     renderUrlRow("Assembly PNG URL", urls.assemblyPngUrl),
@@ -30,6 +107,7 @@ const renderGeneratedUrlRows = (urls: GeneratedSvgUrls) =>
 export const getHtmlForGeneratedUrlPage = (
   codeOrFsMap: GeneratedUrlInput,
   urlPrefix = "https://svg.tscircuit.com",
+  simulationExperiments: SimulationExperimentForGeneratedUrl[] = [],
 ) => {
   const urls = createGeneratedSvgUrls(codeOrFsMap, urlPrefix)
 
@@ -99,7 +177,7 @@ export const getHtmlForGeneratedUrlPage = (
           <th>URL</th>
         </tr>
       </thead>
-      <tbody>${renderGeneratedUrlRows(urls)}
+      <tbody>${renderGeneratedUrlRows(urls, simulationExperiments)}
       </tbody>
     </table>
   </div>

--- a/handlers/generate_urls.ts
+++ b/handlers/generate_urls.ts
@@ -1,5 +1,7 @@
 import type { RequestContext } from "../lib/RequestContext"
 import { getHtmlForGeneratedUrlPage } from "../get-html-for-generated-url-page"
+import { getCircuitJsonFromContext } from "../lib/getCircuitJson"
+import type { SimulationExperiment } from "circuit-json"
 
 export const generateUrlsHandler = async (
   req: Request,
@@ -42,10 +44,25 @@ export const generateUrlsHandler = async (
       )
     }
 
+    const circuitJson = await getCircuitJsonFromContext({
+      ...ctx,
+      fsMap,
+      entrypoint: undefined,
+      mainComponentPath: ctx.mainComponentPath ?? resolvedEntrypoint,
+    })
+    const simulationExperiments = circuitJson.filter(
+      (element: unknown): element is SimulationExperiment =>
+        typeof element === "object" &&
+        element !== null &&
+        "type" in element &&
+        element.type === "simulation_experiment",
+    )
+
     return new Response(
       getHtmlForGeneratedUrlPage(
         { fsMap, entrypoint: resolvedEntrypoint },
         ctx.host,
+        simulationExperiments,
       ),
       {
         headers: { "Content-Type": "text/html" },

--- a/handlers/render-simulation-svg-response.ts
+++ b/handlers/render-simulation-svg-response.ts
@@ -27,21 +27,87 @@ const parseGraphIdsFromQuery = (
     )
     .filter((value, index, values) => values.indexOf(value) === index)
 
-const findSimulationExperimentId = (
+type SimulationExperimentSelection =
+  | { experiment: SimulationExperiment }
+  | { error: string; availableExperiments: SimulationExperiment[] }
+
+const findSimulationExperiment = (
   circuitJson: CircuitJson,
   ctx: RequestContext,
-) => {
+): SimulationExperimentSelection => {
+  const simulationExperiments = circuitJson.filter(
+    (el): el is SimulationExperiment => el.type === "simulation_experiment",
+  )
   const requestedExperimentId =
     ctx.url.searchParams.get("simulation_experiment_id") ??
     ctx.url.searchParams.get("simulationExperimentId") ??
     ctx.simulationExperimentId
 
-  if (requestedExperimentId) return requestedExperimentId
+  if (requestedExperimentId) {
+    const experiment = simulationExperiments.find(
+      (candidate) =>
+        candidate.simulation_experiment_id === requestedExperimentId,
+    )
+    if (experiment) return { experiment }
 
-  return circuitJson.find(
-    (el): el is SimulationExperiment => el.type === "simulation_experiment",
-  )?.simulation_experiment_id
+    return {
+      error: `Simulation experiment id "${requestedExperimentId}" was not found`,
+      availableExperiments: simulationExperiments,
+    }
+  }
+
+  const requestedExperimentName =
+    ctx.url.searchParams.get("simulation_experiment_name") ??
+    ctx.url.searchParams.get("simulationExperimentName") ??
+    ctx.simulationExperimentName
+
+  if (requestedExperimentName) {
+    const matchingExperiments = simulationExperiments.filter(
+      (candidate) => candidate.name === requestedExperimentName,
+    )
+    if (matchingExperiments.length === 1) {
+      return { experiment: matchingExperiments[0] }
+    }
+    if (matchingExperiments.length > 1) {
+      return {
+        error: `Simulation experiment name "${requestedExperimentName}" is ambiguous; select it by simulation_experiment_id instead`,
+        availableExperiments: simulationExperiments,
+      }
+    }
+
+    return {
+      error: `Simulation experiment name "${requestedExperimentName}" was not found`,
+      availableExperiments: simulationExperiments,
+    }
+  }
+
+  const experiment = simulationExperiments[0]
+  if (experiment) return { experiment }
+
+  return {
+    error:
+      "simulation_experiment_id or simulation_experiment_name is required and could not be automatically determined",
+    availableExperiments: [],
+  }
 }
+
+const simulationSelectionErrorResponse = ({
+  error,
+  availableExperiments,
+}: Extract<SimulationExperimentSelection, { error: string }>) =>
+  new Response(
+    JSON.stringify({
+      ok: false,
+      error,
+      available_simulation_experiments: availableExperiments.map(
+        (experiment) => ({
+          simulation_experiment_id: experiment.simulation_experiment_id,
+          name: experiment.name,
+        }),
+      ),
+    }),
+    { status: 400, headers: { "Content-Type": "application/json" } },
+  )
 
 const findSimulationErrorMessage = (
   circuitJson: CircuitJson,
@@ -83,7 +149,12 @@ export const renderSimulationSvgResponse = async (
 ): Promise<Response> => {
   try {
     const circuitJson: CircuitJson = await getCircuitJsonFromContext(ctx)
-    const simulationExperimentId = findSimulationExperimentId(circuitJson, ctx)
+    const simulationSelection = findSimulationExperiment(circuitJson, ctx)
+    if ("error" in simulationSelection) {
+      return simulationSelectionErrorResponse(simulationSelection)
+    }
+    const simulationExperimentId =
+      simulationSelection.experiment.simulation_experiment_id
     const simulationErrorMessage = findSimulationErrorMessage(
       circuitJson,
       simulationExperimentId,
@@ -91,17 +162,6 @@ export const renderSimulationSvgResponse = async (
 
     if (simulationErrorMessage) {
       throw new Error(simulationErrorMessage)
-    }
-
-    if (!simulationExperimentId) {
-      return new Response(
-        JSON.stringify({
-          ok: false,
-          error:
-            "simulation_experiment_id is required and could not be automatically determined",
-        }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      )
     }
 
     const voltageGraphIdsFromQuery = parseGraphIdsFromQuery(

--- a/lib/RequestContext.ts
+++ b/lib/RequestContext.ts
@@ -20,6 +20,7 @@ export interface RequestContext {
   showCourtyards?: boolean
   showInfiniteGrid?: boolean
   simulationExperimentId?: string
+  simulationExperimentName?: string
   simulationTransientVoltageGraphIds?: string[]
   schematicHeightRatio?: number
   requestBody?: unknown

--- a/lib/getRequestContext.ts
+++ b/lib/getRequestContext.ts
@@ -191,6 +191,12 @@ export async function getRequestContext(
       ctx.simulationExperimentId = simulationExperimentId
     }
 
+    const simulationExperimentName =
+      body.simulation_experiment_name ?? body.simulationExperimentName
+    if (typeof simulationExperimentName === "string") {
+      ctx.simulationExperimentName = simulationExperimentName
+    }
+
     const transientGraphIdsInput =
       body.simulation_transient_voltage_graph_ids ??
       body.simulationTransientVoltageGraphIds

--- a/lib/ngspice.ts
+++ b/lib/ngspice.ts
@@ -78,6 +78,16 @@ const createNgspiceEngine = async (): Promise<NgspiceEngine> => ({
 })
 
 let ngspiceEnginePromise: Promise<NgspiceEngine> | undefined
+let simulationQueue = Promise.resolve()
+
+const runSerializedSimulation = <T>(run: () => Promise<T>): Promise<T> => {
+  const result = simulationQueue.then(run)
+  simulationQueue = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  return result
+}
 
 const getNgspiceEngine = () => {
   if (!ngspiceEnginePromise) {
@@ -96,8 +106,10 @@ export const getNgspiceSpiceEngineMap =
   (): PlatformConfig["spiceEngineMap"] => ({
     ngspice: {
       simulate: async (spice) => {
-        const engine = await getNgspiceEngine()
-        return engine.simulate(spice)
+        return runSerializedSimulation(async () => {
+          const engine = await getNgspiceEngine()
+          return engine.simulate(spice)
+        })
       },
     },
   })

--- a/tests/fixtures/multiple-simulation-circuit-code.ts
+++ b/tests/fixtures/multiple-simulation-circuit-code.ts
@@ -1,0 +1,47 @@
+export const multipleSimulationCircuitCode = `
+export default () => (
+  <board routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R1" resistance="1k" />
+    <resistor name="R2" resistance="2k" />
+    <resistor name="R3" resistance="3k" />
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+    <trace from=".R2 > .pin2" to=".R3 > .pin1" />
+    <trace from=".R3 > .pin2" to=".V1 > .pin2" />
+
+    <voltageprobe name="ROOT_PROBE" connectsTo=".V1 > .pin1" />
+    <analogsimulation
+      name="Root Fast"
+      duration="1ms"
+      timePerStep="100us"
+      spiceEngine="ngspice"
+    />
+    <analogsimulation
+      name="Root Slow"
+      duration="2ms"
+      timePerStep="200us"
+      spiceEngine="ngspice"
+    />
+
+    <group name="first-stage">
+      <voltageprobe name="FIRST_STAGE_PROBE" connectsTo=".R1 > .pin2" />
+      <analogsimulation
+        name="Input Group"
+        duration="3ms"
+        timePerStep="300us"
+        spiceEngine="ngspice"
+      />
+    </group>
+    <group name="second-stage">
+      <voltageprobe name="SECOND_STAGE_PROBE" connectsTo=".R2 > .pin2" />
+      <analogsimulation
+        name="Output Group"
+        duration="4ms"
+        timePerStep="400us"
+        spiceEngine="ngspice"
+      />
+    </group>
+  </board>
+)
+`

--- a/tests/generate-urls.test.ts
+++ b/tests/generate-urls.test.ts
@@ -1,26 +1,75 @@
 import { test, expect } from "bun:test"
+import { getHtmlForGeneratedUrlPage } from "../get-html-for-generated-url-page"
 import { getTestServer } from "./fixtures/get-test-server"
+import { multipleSimulationCircuitCode } from "./fixtures/multiple-simulation-circuit-code"
 
-test("POST /generate_urls returns HTML without re-reading the body", async () => {
-  const { serverUrl } = await getTestServer()
+test(
+  "POST /generate_urls returns one named URL pair per simulation",
+  async () => {
+    const { serverUrl } = await getTestServer()
 
-  const response = await fetch(`${serverUrl}/generate_urls`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      fs_map: {
-        "index.tsx": `export default () => (
-  <board width="10mm" height="10mm">
-    <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
-  </board>
-)`,
+    const response = await fetch(`${serverUrl}/generate_urls`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fs_map: { "index.tsx": multipleSimulationCircuitCode },
+        entrypoint: "index.tsx",
+      }),
+    })
+
+    const html = await response.text()
+    if (!response.ok) {
+      throw new Error(
+        `Generate URLs request failed (${response.status}): ${html}`,
+      )
+    }
+    expect(response.headers.get("content-type")).toContain("text/html")
+    expect(html).toContain("svg.tscircuit.com - Generated URLs")
+    for (const name of [
+      "Root Fast",
+      "Root Slow",
+      "Input Group",
+      "Output Group",
+    ]) {
+      expect(html).toContain(`Schematic Simulation SVG URL — ${name}`)
+      expect(html).toContain(`Simulation Graph SVG URL — ${name}`)
+      expect(html).toContain(
+        new URLSearchParams({ simulation_experiment_name: name }).toString(),
+      )
+    }
+  },
+  { timeout: 60_000 },
+)
+
+test("generated simulation URLs use ids when names are duplicated", () => {
+  const html = getHtmlForGeneratedUrlPage(
+    "export default () => <board />",
+    "https://svg.example.com",
+    [
+      {
+        simulation_experiment_id: "simulation_experiment_0",
+        name: "Duplicate",
       },
-      entrypoint: "index.tsx",
-    }),
-  })
+      {
+        simulation_experiment_id: "simulation_experiment_1",
+        name: "Duplicate",
+      },
+    ],
+  )
 
-  expect(response.status).toBe(200)
-  expect(response.headers.get("content-type")).toContain("text/html")
-  const html = await response.text()
-  expect(html).toContain("svg.tscircuit.com - Generated URLs")
+  expect(html).toContain("simulation_experiment_id=simulation_experiment_0")
+  expect(html).toContain("simulation_experiment_id=simulation_experiment_1")
+  expect(html).not.toContain("simulation_experiment_name=Duplicate")
+})
+
+test("generated URL page keeps generic simulation rows without experiments", () => {
+  const html = getHtmlForGeneratedUrlPage(
+    "export default () => <board />",
+    "https://svg.example.com",
+  )
+
+  expect(html).toContain("<td>Schematic Simulation SVG URL</td>")
+  expect(html).toContain("<td>Simulation Graph SVG URL</td>")
+  expect(html).not.toContain("simulation_experiment_name=")
+  expect(html).not.toContain("simulation_experiment_id=")
 })

--- a/tests/multiple-simulation-svg.test.ts
+++ b/tests/multiple-simulation-svg.test.ts
@@ -1,54 +1,7 @@
 import { expect, test } from "bun:test"
 import type { CircuitJson, SimulationExperiment } from "circuit-json"
 import { getTestServer } from "./fixtures/get-test-server"
-
-const multipleSimulationCircuitCode = `
-export default () => (
-  <board routingDisabled>
-    <voltagesource name="V1" voltage="5V" />
-    <resistor name="R1" resistance="1k" />
-    <resistor name="R2" resistance="2k" />
-    <resistor name="R3" resistance="3k" />
-    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
-    <trace from=".R1 > .pin2" to=".R2 > .pin1" />
-    <trace from=".R2 > .pin2" to=".R3 > .pin1" />
-    <trace from=".R3 > .pin2" to=".V1 > .pin2" />
-
-    <voltageprobe name="ROOT_PROBE" connectsTo=".V1 > .pin1" />
-    <analogsimulation
-      name="Root Fast"
-      duration="1ms"
-      timePerStep="100us"
-      spiceEngine="ngspice"
-    />
-    <analogsimulation
-      name="Root Slow"
-      duration="2ms"
-      timePerStep="200us"
-      spiceEngine="ngspice"
-    />
-
-    <group name="first-stage">
-      <voltageprobe name="FIRST_STAGE_PROBE" connectsTo=".R1 > .pin2" />
-      <analogsimulation
-        name="Input Group"
-        duration="3ms"
-        timePerStep="300us"
-        spiceEngine="ngspice"
-      />
-    </group>
-    <group name="second-stage">
-      <voltageprobe name="SECOND_STAGE_PROBE" connectsTo=".R2 > .pin2" />
-      <analogsimulation
-        name="Output Group"
-        duration="4ms"
-        timePerStep="400us"
-        spiceEngine="ngspice"
-      />
-    </group>
-  </board>
-)
-`
+import { multipleSimulationCircuitCode } from "./fixtures/multiple-simulation-circuit-code"
 
 const getExperiment = (circuitJson: CircuitJson, name: string) => {
   const experiment = circuitJson.find(

--- a/tests/multiple-simulation-svg.test.ts
+++ b/tests/multiple-simulation-svg.test.ts
@@ -1,0 +1,177 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson, SimulationExperiment } from "circuit-json"
+import { getTestServer } from "./fixtures/get-test-server"
+
+const multipleSimulationCircuitCode = `
+export default () => (
+  <board routingDisabled>
+    <voltagesource name="V1" voltage="5V" />
+    <resistor name="R1" resistance="1k" />
+    <resistor name="R2" resistance="2k" />
+    <resistor name="R3" resistance="3k" />
+    <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+    <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+    <trace from=".R2 > .pin2" to=".R3 > .pin1" />
+    <trace from=".R3 > .pin2" to=".V1 > .pin2" />
+
+    <voltageprobe name="ROOT_PROBE" connectsTo=".V1 > .pin1" />
+    <analogsimulation
+      name="Root Fast"
+      duration="1ms"
+      timePerStep="100us"
+      spiceEngine="ngspice"
+    />
+    <analogsimulation
+      name="Root Slow"
+      duration="2ms"
+      timePerStep="200us"
+      spiceEngine="ngspice"
+    />
+
+    <group name="first-stage">
+      <voltageprobe name="FIRST_STAGE_PROBE" connectsTo=".R1 > .pin2" />
+      <analogsimulation
+        name="Input Group"
+        duration="3ms"
+        timePerStep="300us"
+        spiceEngine="ngspice"
+      />
+    </group>
+    <group name="second-stage">
+      <voltageprobe name="SECOND_STAGE_PROBE" connectsTo=".R2 > .pin2" />
+      <analogsimulation
+        name="Output Group"
+        duration="4ms"
+        timePerStep="400us"
+        spiceEngine="ngspice"
+      />
+    </group>
+  </board>
+)
+`
+
+const getExperiment = (circuitJson: CircuitJson, name: string) => {
+  const experiment = circuitJson.find(
+    (element): element is SimulationExperiment =>
+      element.type === "simulation_experiment" && element.name === name,
+  )
+  if (!experiment) throw new Error(`Missing simulation experiment: ${name}`)
+  return experiment
+}
+
+test(
+  "renders each named simulation from a real multi-simulation ngspice run",
+  async () => {
+    const { serverUrl } = await getTestServer()
+    const circuitJsonResponse = await fetch(
+      `${serverUrl}?format=circuit_json`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fs_map: { "index.tsx": multipleSimulationCircuitCode },
+          main_component_path: "index.tsx",
+        }),
+      },
+    )
+
+    const circuitJsonResponseText = await circuitJsonResponse.text()
+    if (!circuitJsonResponse.ok) {
+      throw new Error(
+        `Circuit JSON request failed (${circuitJsonResponse.status}): ${circuitJsonResponseText}`,
+      )
+    }
+    const circuitJson = JSON.parse(circuitJsonResponseText) as CircuitJson
+    const experiments = circuitJson.filter(
+      (element): element is SimulationExperiment =>
+        element.type === "simulation_experiment",
+    )
+    expect(experiments.map((experiment) => experiment.name)).toEqual([
+      "Root Fast",
+      "Root Slow",
+      "Input Group",
+      "Output Group",
+    ])
+    expect(
+      circuitJson.filter(
+        (element) => element.type === "simulation_transient_voltage_graph",
+      ),
+    ).toHaveLength(8)
+    expect(
+      circuitJson.filter(
+        (element) => element.type === "simulation_unknown_experiment_error",
+      ),
+    ).toHaveLength(0)
+
+    const rootFast = getExperiment(circuitJson, "Root Fast")
+    const defaultResponse = await fetch(`${serverUrl}?svg_type=sim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ circuit_json: circuitJson }),
+    })
+    const defaultSvg = await defaultResponse.text()
+    expect(defaultResponse.status).toBe(200)
+    expect(defaultSvg).toContain(rootFast.simulation_experiment_id)
+
+    const outputGroup = getExperiment(circuitJson, "Output Group")
+    const namedResponse = await fetch(
+      `${serverUrl}?svg_type=sim&simulation_experiment_name=${encodeURIComponent("Output Group")}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ circuit_json: circuitJson }),
+      },
+    )
+    const namedSvg = await namedResponse.text()
+    expect(namedResponse.status).toBe(200)
+    expect(namedSvg).toContain(outputGroup.simulation_experiment_id)
+    expect(namedSvg).toContain("SECOND_STAGE_PROBE")
+    expect(namedSvg).not.toContain("ROOT_PROBE")
+    expect(namedSvg).not.toContain("FIRST_STAGE_PROBE")
+
+    const inputGroup = getExperiment(circuitJson, "Input Group")
+    const bodyNameResponse = await fetch(`${serverUrl}?svg_type=schsim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        circuit_json: circuitJson,
+        simulation_experiment_name: "Input Group",
+      }),
+    })
+    const bodyNameSvg = await bodyNameResponse.text()
+    expect(bodyNameResponse.status).toBe(200)
+    expect(bodyNameSvg).toContain(inputGroup.simulation_experiment_id)
+
+    const missingResponse = await fetch(
+      `${serverUrl}?svg_type=sim&simulation_experiment_name=Missing`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ circuit_json: circuitJson }),
+      },
+    )
+    const missingBody = await missingResponse.json()
+    expect(missingResponse.status).toBe(400)
+    expect(missingBody.error).toContain('name "Missing" was not found')
+    expect(missingBody.available_simulation_experiments).toHaveLength(4)
+
+    const circuitJsonWithDuplicateNames = circuitJson.map((element) =>
+      element.type === "simulation_experiment" &&
+      ["Root Fast", "Root Slow"].includes(element.name)
+        ? { ...element, name: "Duplicate" }
+        : element,
+    ) as CircuitJson
+    const ambiguousResponse = await fetch(
+      `${serverUrl}?svg_type=sim&simulation_experiment_name=Duplicate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ circuit_json: circuitJsonWithDuplicateNames }),
+      },
+    )
+    const ambiguousBody = await ambiguousResponse.json()
+    expect(ambiguousResponse.status).toBe(400)
+    expect(ambiguousBody.error).toContain("is ambiguous")
+  },
+  { timeout: 60_000 },
+)


### PR DESCRIPTION
## Summary

- allow `sim` and `schsim` requests to select an analog simulation by experiment name or Circuit JSON id
- make the homepage discover pasted-circuit experiments and generate one `sim`/`schsim` URL pair per simulation
- preserve first-experiment rendering when no selector is supplied and fall back to ids for missing or duplicate names
- serialize calls to the shared ngspice engine so circuits with multiple experiments run reliably
- add real four-experiment ngspice coverage for root and group simulations and generated homepage URLs

## Why

Core can now produce multiple analog simulations in one circuit, but the SVG service previously rendered only the first experiment unless callers already knew its generated id. The homepage likewise emitted only one unqualified simulation URL pair. Named selection gives documentation and other consumers a stable way to request one static SVG for each experiment.

## User impact

Callers can pass `simulation_experiment_name` or `simulation_experiment_id` in the query string or POST body. Existing URLs continue to render the first simulation. On the homepage, users can paste a multi-simulation circuit and receive separately labeled graph and schematic-simulation URLs for every experiment.

## Validation

- `bun test tests/generate-urls.test.ts tests/multiple-simulation-svg.test.ts tests/schematic-simulation-svg.test.ts`
- manual Next dev-server flow: pasted the four-simulation fixture, generated eight named links, and opened the `Output Group` SVG
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
